### PR TITLE
Fix plugin test import

### DIFF
--- a/packages/markitdown-sample-plugin/tests/__init__.py
+++ b/packages/markitdown-sample-plugin/tests/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2024-present Adam Fourney <adamfo@microsoft.com>
-#
-# SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Summary
- delete `packages/markitdown-sample-plugin/tests/__init__.py` so pytest doesn't try to import from the package name containing a hyphen

## Testing
- `pip install -e packages/markitdown[all]`
- `pip install -e packages/markitdown-sample-plugin`
- `GITHUB_ACTIONS=true pytest packages/markitdown/tests/test_cli_misc.py packages/markitdown/tests/test_module_misc.py packages/markitdown-sample-plugin/tests/test_sample_plugin.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a42c6d18832fae1adb5e806d47bc