### PR TITLE
Fix plugin test import issue

### DIFF
--- a/packages/markitdown-sample-plugin/tests/__init__.py
+++ b/packages/markitdown-sample-plugin/tests/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2024-present Adam Fourney <adamfo@microsoft.com>
-#
-# SPDX-License-Identifier: MIT


### PR DESCRIPTION
## Summary
- remove package `__init__` from plugin tests so pytest can import them from repository root

## Testing
- `pytest -q` *(fails: File conversion failed, missing ffprobe)*

------
https://chatgpt.com/codex/tasks/task_e_6878a42c6d18832fae1adb5e806d47bc