### PR TITLE
Propagate keep_data_uris option in ZipConverter

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_zip_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_zip_converter.py
@@ -101,9 +101,14 @@ class ZipConverter(DocumentConverter):
                         extension=os.path.splitext(name)[1],
                         filename=os.path.basename(name),
                     )
+                    nested_kwargs = {}
+                    if "keep_data_uris" in kwargs:
+                        nested_kwargs["keep_data_uris"] = kwargs["keep_data_uris"]
+
                     result = self._markitdown.convert_stream(
                         stream=z_file_stream,
                         stream_info=z_file_stream_info,
+                        **nested_kwargs,
                     )
                     if result is not None:
                         md_content += f"## File: {name}\n\n"


### PR DESCRIPTION
## Summary
- forward the `keep_data_uris` flag when converting files inside ZIP archives

## Testing
- `GITHUB_ACTIONS=1 pytest packages/markitdown/tests/test_module_vectors.py::test_convert_local -q`
- `GITHUB_ACTIONS=1 pytest packages/markitdown/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a42c6d18832fae1adb5e806d47bc