### PR TITLE
Fix README typo

### DIFF
--- a/packages/markitdown-mcp/README.md
+++ b/packages/markitdown-mcp/README.md
@@ -54,7 +54,7 @@ Once mounted, all files under data will be accessible under `/workdir` in the co
 
 It is recommended to use the Docker image when running the MCP server for Claude Desktop.
 
-Follow [these instrutions](https://modelcontextprotocol.io/quickstart/user#for-claude-desktop-users) to access Claude's `claude_desktop_config.json` file.
+Follow [these instructions](https://modelcontextprotocol.io/quickstart/user#for-claude-desktop-users) to access Claude's `claude_desktop_config.json` file.
 
 Edit it to include the following JSON entry:
 


### PR DESCRIPTION
## Summary
- fix typo in Claude Desktop instructions

## Testing
- `GITHUB_ACTIONS=1 pytest packages/markitdown/tests -q`
- `GITHUB_ACTIONS=1 pytest packages/markitdown-sample-plugin/tests/test_sample_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a65cbf44832fa6b64f6b0fa1fef6