### PR TITLE
Fix typo in sample plugin comment

### DIFF
--- a/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
+++ b/packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py
@@ -60,7 +60,7 @@ class RtfConverter(DocumentConverter):
         stream_info: StreamInfo,
         **kwargs: Any,
     ) -> DocumentConverterResult:
-        # Read the file stream into an str using hte provided charset encoding, or using the system default
+        # Read the file stream into an str using the provided charset encoding, or using the system default
         encoding = stream_info.charset or locale.getpreferredencoding()
         stream_data = file_stream.read().decode(encoding)
 


### PR DESCRIPTION
## Summary
- correct a small typo in the sample plugin comment

## Testing
- `pre-commit run --files packages/markitdown-sample-plugin/src/markitdown_sample_plugin/_plugin.py`
- `cd packages/markitdown-sample-plugin && hatch test`

------
https://chatgpt.com/codex/tasks/task_e_6878a65bdb1c832f97a5e4eb93768d77