### PR TITLE
Fix MarkItDown spelling in transcribe_audio

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
+++ b/packages/markitdown/src/markitdown/converters/_transcribe_audio.py
@@ -24,7 +24,7 @@ def transcribe_audio(file_stream: BinaryIO, *, audio_format: str = "wav") -> str
     # Check for installed dependencies
     if _dependency_exc_info is not None:
         raise MissingDependencyException(
-            "Speech transcription requires installing MarkItdown with the [audio-transcription] optional dependencies. E.g., `pip install markitdown[audio-transcription]` or `pip install markitdown[all]`"
+            "Speech transcription requires installing MarkItDown with the [audio-transcription] optional dependencies. E.g., `pip install markitdown[audio-transcription]` or `pip install markitdown[all]`"
         ) from _dependency_exc_info[
             1
         ].with_traceback(  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary
- fix MarkItDown spelling in missing dependency message for audio transcription

## Testing
- `hatch test` *(fails: File conversion failed due to missing ffprobe, network issues)*
- `pre-commit run --all-files`


------
https://chatgpt.com/codex/tasks/task_e_6878a656c884832facda966a8653ee90