### PR TITLE
Strengthen version output assertion in CLI tests

### DIFF
--- a/packages/markitdown/tests/test_cli_misc.py
+++ b/packages/markitdown/tests/test_cli_misc.py
@@ -12,7 +12,9 @@ def test_version() -> None:
     )
 
     assert result.returncode == 0, f"CLI exited with error: {result.stderr}"
-    assert __version__ in result.stdout, f"Version not found in output: {result.stdout}"
+    assert (
+        result.stdout.strip() == f"markitdown {__version__}"
+    ), f"Unexpected version output: {result.stdout}"
 
 
 def test_invalid_flag() -> None:


### PR DESCRIPTION
## Summary
- tighten CLI version test to check full version output

## Testing
- `PYTHONPATH=packages/markitdown/src pytest packages/markitdown/tests/test_cli_misc.py::test_version -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a655ae34832f85fa24b6a5f09391