### PR TITLE
Fix comment typo

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py
@@ -54,7 +54,7 @@ class OutlookMsgConverter(DocumentConverter):
         finally:
             file_stream.seek(cur_pos)
 
-        # Brue force, check if it's an Outlook file
+        # Brute force, check if it's an Outlook file
         try:
             if olefile is not None:
                 msg = olefile.OleFileIO(file_stream)


### PR DESCRIPTION
## Summary
- fix comment typo `Brute force` in OutlookMsgConverter

## Testing
- `pre-commit run --files packages/markitdown/src/markitdown/converters/_outlook_msg_converter.py`
- `hatch test` *(fails: FileConversionException - couldn't find ffprobe)*

------
https://chatgpt.com/codex/tasks/task_e_6878a653ac1c832f977c865d895cacc3