### PR TITLE
Fix stdin CLI test

### DIFF
--- a/packages/markitdown/tests/test_cli_vectors.py
+++ b/packages/markitdown/tests/test_cli_vectors.py
@@ -107,7 +107,6 @@ def test_input_from_stdin_without_hints(shared_tmp_dir, test_vector) -> None:
             "python",
             "-m",
             "markitdown",
-            os.path.join(TEST_FILES_DIR, test_vector.filename),
         ],
         input=test_input,
         capture_output=True,


### PR DESCRIPTION
## Summary
- update CLI stdin test to avoid passing a filename argument

## Testing
- `pytest packages/markitdown/tests/test_cli_vectors.py::test_input_from_stdin_without_hints -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a65223f8832fa5a0086a759fe98a