### PR TITLE
Fix docstring typos

### DIFF
--- a/packages/markitdown/src/markitdown/_base_converter.py
+++ b/packages/markitdown/src/markitdown/_base_converter.py
@@ -50,18 +50,18 @@ class DocumentConverter:
     ) -> bool:
         """
         Return a quick determination on if the converter should attempt converting the document.
-        This is primarily based `stream_info` (typically, `stream_info.mimetype`, `stream_info.extension`).
-        In cases where the data is retrieved via HTTP, the `steam_info.url` might also be referenced to
+        This is primarily based on `stream_info` (typically, `stream_info.mimetype`, `stream_info.extension`).
+        In cases where the data is retrieved via HTTP, the `stream_info.url` might also be referenced to
         make a determination (e.g., special converters for Wikipedia, YouTube etc).
-        Finally, it is conceivable that the `stream_info.filename` might be used to in cases
+        Finally, it is conceivable that the `stream_info.filename` might be used in cases
         where the filename is well-known (e.g., `Dockerfile`, `Makefile`, etc)
 
         NOTE: The method signature is designed to match that of the convert() method. This provides some
         assurance that, if accepts() returns True, the convert() method will also be able to handle the document.
 
         IMPORTANT: In rare cases, (e.g., OutlookMsgConverter) we need to read more from the stream to make a final
-        determination. Read operations inevitably advances the position in file_stream. In these case, the position
-        MUST be reset it MUST be reset before returning. This is because the convert() method may be called immediately
+        determination. Read operations inevitably advance the position in file_stream. In these cases, the position
+        MUST be reset before returning. This is because the convert() method may be called immediately
         after accepts(), and will expect the file_stream to be at the original position.
 
         E.g.,
@@ -69,9 +69,9 @@ class DocumentConverter:
         data = file_stream.read(100) # ... peek at the first 100 bytes, etc.
         file_stream.seek(cur_pos)    # Reset the position to the original position
 
-        Prameters:
+        Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
-        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
+        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, etc.)
         - kwargs: Additional keyword arguments for the converter.
 
         Returns:
@@ -90,9 +90,9 @@ class DocumentConverter:
         """
         Convert a document to Markdown text.
 
-        Prameters:
+        Parameters:
         - file_stream: The file-like object to convert. Must support seek(), tell(), and read() methods.
-        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, set)
+        - stream_info: The StreamInfo object containing metadata about the file (mimetype, extension, charset, etc.)
         - kwargs: Additional keyword arguments for the converter.
 
         Returns:


### PR DESCRIPTION
## Summary
- correct `Parameters` in `DocumentConverter` methods
- clean up surrounding docstring typos

## Testing
- `pre-commit run --files packages/markitdown/src/markitdown/_base_converter.py`
- `pytest packages/markitdown/tests packages/markitdown-mcp/tests -q` *(fails: MissingDependencyException, network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6878a651c944832f84d337ee0bb90fe2