### PR TITLE
Fix priority name in docstring

### DIFF
--- a/packages/markitdown/src/markitdown/_markitdown.py
+++ b/packages/markitdown/src/markitdown/_markitdown.py
@@ -638,7 +638,7 @@ class MarkItDown:
         Priorities work as follows: By default, most converters get priority
         DocumentConverter.PRIORITY_SPECIFIC_FILE_FORMAT (== 0). The exception
         is the PlainTextConverter, HtmlConverter, and ZipConverter, which get
-        priority PRIORITY_SPECIFIC_FILE_FORMAT (== 10), with lower values
+        priority PRIORITY_GENERIC_FILE_FORMAT (== 10), with lower values
         being tried first (i.e., higher priority).
 
         Just prior to conversion, the converters are sorted by priority, using


### PR DESCRIPTION
## Summary
- correct the priority constant name in the `register_converter` docstring

## Testing
- `pip install -e packages/markitdown`
- `pytest -q packages/markitdown/tests` *(fails: KeyboardInterrupt and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6878a64e1110832f854881e0aa2ceb67