### PR TITLE
Fix audio converter extension handling

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_audio_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_audio_converter.py
@@ -75,15 +75,16 @@ class AudioConverter(DocumentConverter):
                 if f in metadata:
                     md_content += f"{f}: {metadata[f]}\n"
 
+        # Normalize case for reliable extension and MIME type comparisons
+        extension = (stream_info.extension or "").lower()
+        mimetype = (stream_info.mimetype or "").lower()
+
         # Figure out the audio format for transcription
-        if stream_info.extension == ".wav" or stream_info.mimetype == "audio/x-wav":
+        if extension == ".wav" or mimetype == "audio/x-wav":
             audio_format = "wav"
-        elif stream_info.extension == ".mp3" or stream_info.mimetype == "audio/mpeg":
+        elif extension == ".mp3" or mimetype == "audio/mpeg":
             audio_format = "mp3"
-        elif (
-            stream_info.extension in [".mp4", ".m4a"]
-            or stream_info.mimetype == "video/mp4"
-        ):
+        elif extension in [".mp4", ".m4a"] or mimetype == "video/mp4":
             audio_format = "mp4"
         else:
             audio_format = None

--- a/packages/markitdown/tests/test_module_misc.py
+++ b/packages/markitdown/tests/test_module_misc.py
@@ -325,6 +325,28 @@ def test_speech_transcription() -> None:
         )
 
 
+@pytest.mark.skipif(
+    skip_remote,
+    reason="do not run remotely run speech transcription tests",
+)
+def test_uppercase_extension_transcription() -> None:
+    """Ensure uppercase audio extensions are recognized."""
+    markitdown = MarkItDown()
+
+    result = markitdown.convert(
+        os.path.join(TEST_FILES_DIR, "test.wav"),
+        file_extension=".WAV",
+    )
+    result_lower = result.text_content.lower()
+    assert (
+        ("1" in result_lower or "one" in result_lower)
+        and ("2" in result_lower or "two" in result_lower)
+        and ("3" in result_lower or "three" in result_lower)
+        and ("4" in result_lower or "four" in result_lower)
+        and ("5" in result_lower or "five" in result_lower)
+    )
+
+
 def test_exceptions() -> None:
     # Check that an exception is raised when trying to convert an unsupported format
     markitdown = MarkItDown()


### PR DESCRIPTION
## Summary
- normalize extension and mimetype in AudioConverter.convert
- add regression test for uppercase audio extension

## Testing
- `pytest -q --import-mode=importlib`

------
https://chatgpt.com/codex/tasks/task_e_6878a64d9cb0832f9a37cd18959c489d