### PR TITLE
Add HTML support for Document Intelligence

### DIFF
--- a/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
+++ b/packages/markitdown/src/markitdown/converters/_doc_intel_converter.py
@@ -84,6 +84,9 @@ def _get_mime_type_prefixes(types: List[DocumentIntelligenceFileType]) -> List[s
             prefixes.append(
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             )
+        elif type_ == DocumentIntelligenceFileType.HTML:
+            prefixes.append("text/html")
+            prefixes.append("application/xhtml+xml")
         elif type_ == DocumentIntelligenceFileType.PDF:
             prefixes.append("application/pdf")
             prefixes.append("application/x-pdf")
@@ -119,6 +122,8 @@ def _get_file_extensions(types: List[DocumentIntelligenceFileType]) -> List[str]
             extensions.append(".bmp")
         elif type_ == DocumentIntelligenceFileType.TIFF:
             extensions.append(".tiff")
+        elif type_ == DocumentIntelligenceFileType.HTML:
+            extensions.append(".html")
     return extensions
 
 

--- a/packages/markitdown/tests/test_docintel_html.py
+++ b/packages/markitdown/tests/test_docintel_html.py
@@ -1,0 +1,26 @@
+import io
+from markitdown.converters._doc_intel_converter import (
+    DocumentIntelligenceConverter,
+    DocumentIntelligenceFileType,
+)
+from markitdown._stream_info import StreamInfo
+
+
+def _make_converter(file_types):
+    conv = DocumentIntelligenceConverter.__new__(DocumentIntelligenceConverter)
+    conv._file_types = file_types
+    return conv
+
+
+def test_docintel_accepts_html_extension():
+    conv = _make_converter([DocumentIntelligenceFileType.HTML])
+    stream_info = StreamInfo(mimetype=None, extension=".html")
+    assert conv.accepts(io.BytesIO(b""), stream_info)
+
+
+def test_docintel_accepts_html_mimetype():
+    conv = _make_converter([DocumentIntelligenceFileType.HTML])
+    stream_info = StreamInfo(mimetype="text/html", extension=None)
+    assert conv.accepts(io.BytesIO(b""), stream_info)
+    stream_info = StreamInfo(mimetype="application/xhtml+xml", extension=None)
+    assert conv.accepts(io.BytesIO(b""), stream_info)


### PR DESCRIPTION
## Summary
- extend DocumentIntelligenceConverter helpers for HTML
- ensure HTML files are recognized
- add unit tests for HTML acceptance

## Testing
- `pytest packages/markitdown/tests -q`
- `pytest packages/markitdown-sample-plugin/tests/test_sample_plugin.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6878a65b9670832f96a2b628f8752326